### PR TITLE
Support for translating navbar items

### DIFF
--- a/Data/translations/navbar.csv
+++ b/Data/translations/navbar.csv
@@ -1,0 +1,22 @@
+key,en,fr
+home,Home,Accueil
+viz,Visualizations,Visualisations
+obs_hosp_census,Observed Hospital Census,Recensement des hôpitaux observés
+obs_daily_hosp_adms,Observed Daily Hospital Admissions,Admissions quotidiennes à l'hôpital
+peak_hosp_projs,Peak hospitalization projections,Projections d'hospitalisation de pointe
+hosp_projs,Hospitalization Projections,Projections d'hospitalisation
+vent_projs,Ventilator Projections,Projections de ventilateur
+death_viz,Death visualization,Visualisation de la mort
+phys_dist,Physical distancing,Distanciation physique
+model,Model,Modèle
+model_params,Model parameters,Paramètres du modèle
+hosp_data,Hospital data,Données hospitalières
+inp_params,Input parameters,Paramètres d'entrée
+refs,References,Références
+more,More,Plus
+model_use,Model use,Utilisation du modèle
+model_acc,Model accuracy,Précision du modèle
+scens_phys_dist,Scenarios of physical distancing,Scénarios de distanciation physique
+phys_dist_effect,Physical distancing effectiveness,Efficacité de l'éloignement physique
+contact,Contact,Contact
+changelog,Changelog,Changelog

--- a/config.toml
+++ b/config.toml
@@ -22,154 +22,153 @@ publishDir = "./docs"
 [permalinks]
     post = "/:year/:month/:day/:slug/"
 
-
 [[menu.main]]
-    name = "Home"
+    name = "home"
     url = "/"
     weight = 1
 
 [[menu.main]]
-    name = " Visualizations"
+    name = "viz"
     url = ""
     weight = 2
     
 [[menu.main]]
-    name = " Observed hospital census"
+    name = "obs_hosp_census"
     url = "/#observed-census"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 1
     
 [[menu.main]]
-    name = " Observed daily hospital admissions"
+    name = "obs_daily_hosp_adms"
     url = "/#observed-admits"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 2
 
 [[menu.main]]
-    name = "Peak hospitalization projections"
+    name = "peak_hosp_projs"
     url = "/#peak-hosp-projections"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 3
     
 [[menu.main]]
-    name = "Hospitalization Projections"
+    name = "hosp_projs"
     url = "/#hospitalization-projections"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 4
 
 [[menu.main]]
-    name = "Ventilator Projections"
+    name = "vent_projs"
     url = "/#ventilator-projections"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 5
     
 [[menu.main]]
-    name = "Death visualization"
+    name = "death_viz"
     url = "/#death-visualization"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 6
     
 [[menu.main]]
-    name = "Physical distancing"
+    name = "phys_dist"
     url = "/more/#distancing"
-    parent = " Visualizations"
+    parent = "viz"
     weight = 7
 
 [[menu.main]]
-    name = " Model"
+    name = "model"
     url = "/model/"
     weight = 3
     
 [[menu.main]]
-    name = "Model parameters"
+    name = "model_params"
     url = "/model/"
-    parent = " Model"
+    parent = "model"
     weight = 1
     
 [[menu.main]]
-    name = "Hospital data"
+    name = "hosp_data"
     url = "/model/#hospital-census"
-    parent = " Model"
+    parent = "model"
     weight = 2
 
 [[menu.main]]
-    name = "Physical distancing"
+    name = "phys_dist"
     url = "/model/#physical-distancing"
-    parent = " Model"
+    parent = "model"
     weight = 3
 
 [[menu.main]]
-    name = "Physical distancing"
+    name = "phys_dist"
     url = "/model/#distancing-math"
-    parent = " Model"
+    parent = "model"
     weight = 4
     
 [[menu.main]]
-    name = "Physical distancing"
+    name = "phys_dist"
     url = "/model/#distancing"
-    parent = " Model"
+    parent = "model"
     weight = 5
     
 [[menu.main]]
-    name = "Input parameters"
+    name = "inp_params"
     url = "/model/#parameters"
-    parent = " Model"
+    parent = "model"
     weight = 6
 
 [[menu.main]]
-    name = "Input parameters"
+    name = "inp_params"
     url = "/model/#plot-data"
-    parent = " Model"
+    parent = "model"
     weight = 7
     
 [[menu.main]]
-    name = "References"
+    name = "refs"
     url = "/model/#references"
-    parent = " Model"
+    parent = "model"
     weight = 8
 
 [[menu.main]]
-    name = " More"
+    name = "more"
     url = "/more/"
     weight = 4
     
 [[menu.main]]
-    name = "Model use"
+    name = "model_use"
     url = "/more/#use"
-    parent = " More"
+    parent = "more"
     weight = 1
 
 [[menu.main]]
-    name = "Model accuracy"
+    name = "model_acc"
     url = "/more/#accuracy"
-    parent = " More"
+    parent = "more"
     weight = 2   
     
 [[menu.main]]
-    name = "Scenarios of physical distancing"
+    name = "scens_phys_dist"
     url = "/more/#scenarios"
-    parent = " More"
+    parent = "more"
     weight = 3  
     
 [[menu.main]]
-    name = "Physical distancing"
+    name = "phys_dist"
     url = "/more/#distancing"
-    parent = " More"
+    parent = "more"
     weight = 4 
     
 [[menu.main]]
-    name = "Physical distancing effectiveness"
+    name = "phys_dist_effect"
     url = "/more/#distancing-effectiveness"
-    parent = " More"
+    parent = "more"
     weight = 5
 
 [[menu.main]]
-    name = "Contact"
+    name = "contact"
     url = "/contact/"
     weight = 5
 
 [[menu.main]]
-    name = "Changelog"
+    name = "changelog"
     url = "/change-log/"
     weight = 6
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -18,22 +18,22 @@
                     <a 
                         class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" href="#" role="button"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        {{ .Name }}
+                        {{ partial "translate.html" (dict "lang" site.Language.Lang "key" .Name) }}
                     </a>
                     <div 
                         class="dropdown-menu navbar-dropdown" aria-labelledby="navbarDropdownMenuLink" id="viz-dropdown">
                     {{ range .Children }}
                         <a 
                             class="dropdown-item" 
-                            href="{{ .URL }}">
-                            {{ .Name }}
+                            href="{{ print site.LanguagePrefix .URL }}">
+                            {{ partial "translate.html" (dict "lang" site.Language.Lang "key" .Name) }}
                         </a>
                     {{ end }}
                     </div>
                 </li>
                 {{ else }}
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ .URL }}">{{ .Name }}</a>
+                        <a class="nav-link" href="{{ print site.LanguagePrefix .URL }}">{{ partial "translate.html" (dict "lang" site.Language.Lang "key" .Name) }}</a>
                     </li>
                 {{ end }}
             {{ end }}

--- a/layouts/partials/translate.html
+++ b/layouts/partials/translate.html
@@ -1,0 +1,16 @@
+{{ $translations := getCSV "," "Data/translations/navbar.csv" }}
+{{ $langIndex := 1 }}
+{{range $i, $r := index $translations 0 }}
+    {{ if eq $r $.lang }}
+        {{ $langIndex = $i }}
+    {{ end }}
+{{end}}
+
+{{ $translatedValue := "Error"}}
+{{ range $i, $r := $translations }}
+  {{ if eq (trim (index $r 0) " ") ($.key) }}
+    {{ $translatedValue = (index $r $langIndex) }}
+  {{ end }}
+{{ end }}
+
+{{ return $translatedValue }}


### PR DESCRIPTION
* Added new CSV file called navbar.csv to the Data/translations folder which follows the same format as the Home translations CSV file. Contains the translations from en to fr for the navbar.
* Updated hugo files (nav.html and added translate.html) to implement translations
* Updated the config TOML file for hugo, specifically the [[menu.main]] items. The name field should now refer to a value from the key column in the translations CSV file. The value should follow is case-sensitive although spaces around the value don't matter.

I did not include the docs and content files since they would clutter up the PR, so you will need to build the site before running it to see the translations. Changing values in the CSV file does not trigger a rebuild, you will have to call `blogdown::build_site()` manually. For now, the french translations come from Google translate.