### PR TITLE
Remove figures and information that use/reference OPH case data

### DIFF
--- a/content/en/_index.Rmd
+++ b/content/en/_index.Rmd
@@ -8,7 +8,6 @@ output:
   word_document: default
 ---
 
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 lang <- params$lang
@@ -35,6 +34,7 @@ site <- "CovidEmployeeData"
 ```
 
 `r intro`
+
 ```{r echo=FALSE, message=FALSE, warning=FALSE}
 
 # libraries
@@ -328,28 +328,6 @@ hosp_projections <- insert_translation(localization_data, lang, "hosp_projection
 
 `r dashboard_HCWcovid`
 
-`r past_data_title`
-
-`r observed_cases`
-
-```{r, echo=FALSE, warning=FALSE, message=FALSE}
-# Visualize current daily cases
-source("../../R/observed_data.R")
-observed_new_episodes <- list(type = "observed_data", y_column = "observed_new_episodes", name = "New cases by episode date", color = current_case_hex)
-constrain_val = as.Date(last(ott_observed$date)) - as.Date(first(ott_observed$date))
-constrain_val = day(days(constrain_val))
-reworked_figure(
-    xaxis = "date",
-    yaxis = list(observed_new_episodes),
-    titles = c(y = "Daily cases", x = "Date", title = "Observed daily COVID-19 cases in Ottawa by episode date", ticklabels = "%b %y"),
-    data = ott_observed, date_constraint = TRUE, constraint_val =  constrain_val
-  )
-```
-
-`r observed_cases_text`
-
-`r line_break`
-
 `r observed_staff_cases`
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
@@ -413,21 +391,18 @@ ICU_p_acute_care
 
 `r line_break`
 
-`r hosp_projections`
-`r hosp_projections_text`
+`r hosp_projections` `r hosp_projections_text`
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
 # visualize epinow forecast
 #short_term_plot(projections = ott_projections, obs_data = ott_observed, obs_column = "observed_new_cases", forecast_type = "reported_cases", ylab = "New cases", title = "Short-term daily COVID-19 cases in Ottawa by reported date")
 ```
 
-
 ```{r, echo=FALSE, warning=FALSE, message=FALSE}
 # visualize epinow forecast
 interval_num <- tail(as.Date(hosp_proj$date), 2)[[1]] - as.Date("2021-12-01")
 short_term_plot(projections = hosp_proj, obs_data = ott_observed, obs_column = "observed_census_ICU_p_acute_care", forecast_type = "reported_cases", ylab = "Hospital census", title = "Projection of hospital census in Ottawa", tick_labels_date = "%b %y", tick_period = "1 month", interval_num = interval_num)
 ```
-
 
 `r line_break`
 

--- a/content/en/wastewater.Rmd
+++ b/content/en/wastewater.Rmd
@@ -229,7 +229,9 @@ reworked_figure(xaxis = "date", yaxis = list(daily_viral_signal_call, daily_vira
 
 ------------------------------------------------------------------------
 
-The next plot illustrates the 7-day rolling mean in daily COVID-19 wastewater viral signal. This number is the average of a week's readings; today's reading with the previous six days. Also on the graph are various comparators (e.g. reported daily COVID-19 cases, hospitalization count), which can be individually selected by toggling the menu on the right.
+The next plot illustrates the 7-day rolling mean in daily COVID-19 wastewater viral signal. This number is the average of a week's readings; today's reading with the previous six days. Also on the graph are various comparators (e.g. hospitalization count), which can be individually selected by toggling the menu on the right.
+
+<!-- Remove all comparators for this plot except 'hospitalizations' and '% positivity' -->
 
 ------------------------------------------------------------------------
 
@@ -401,23 +403,24 @@ p <- reworked_figure(xaxis = "date", yaxis = list(daily_rsv_signal, rsv_7_day), 
 p <- layout(p, yaxis = list(range = c(0, 0.0008500), exponentformat="none", tickformat=".5f"))
 p
 ```
-```
+
+\`\`\`
 
 ------------------------------------------------------------------------
 
 ## Interpretation cautions
 
-The accuracy and reliability of SARS-CoV-2, influenza and RSV wastewater testing is improving as scientists understand the role of factors such as differences in sewage systems and laboratory protocols. Nonetheless, we recommend caution when interpreting daily or less then 3-day variation in the viral signal while evaluation of the methodology in public health surveillance is ongoing. Research is underway to arrive at a more precise estimate of sensitivity. For influenza and RSV, the level of detection is currently unknown as less than a year’s worth of data has been collected, but evaluation is ongoing. Thus, direct comparisons between wastewater signal levels for the 3 viruses is not recommended at this time. COVID-19, influenza and RSV wastewater signal is helpful when interpreted alongside other surveillance measures, taking into consideration the strengths and limitations of each measure. It is most promising as an early indicator$^2$ of community viral activity and illness and may serve as a warning in advance of increased care-seeking, outbreaks and hospitalizations.  
+The accuracy and reliability of SARS-CoV-2, influenza and RSV wastewater testing is improving as scientists understand the role of factors such as differences in sewage systems and laboratory protocols. Nonetheless, we recommend caution when interpreting daily or less then 3-day variation in the viral signal while evaluation of the methodology in public health surveillance is ongoing. Research is underway to arrive at a more precise estimate of sensitivity. For influenza and RSV, the level of detection is currently unknown as less than a year's worth of data has been collected, but evaluation is ongoing. Thus, direct comparisons between wastewater signal levels for the 3 viruses is not recommended at this time. COVID-19, influenza and RSV wastewater signal is helpful when interpreted alongside other surveillance measures, taking into consideration the strengths and limitations of each measure. It is most promising as an early indicator$^2$ of community viral activity and illness and may serve as a warning in advance of increased care-seeking, outbreaks and hospitalizations.
 
-Visit the Ottawa Public Health [Respiratory and Enteric Surveillance Report](https://www.ottawapublichealth.ca/en/reports-research-and-statistics/flu-report.aspx) for more information on Ottawa’s public health surveillance of respiratory and enteric viruses.  
+Visit the Ottawa Public Health [Respiratory and Enteric Surveillance Report](https://www.ottawapublichealth.ca/en/reports-research-and-statistics/flu-report.aspx) for more information on Ottawa's public health surveillance of respiratory and enteric viruses.
 
-For more information on wastewater testing in Ottawa, please see the [contact](https://613covid.ca/contact/) page. 
+For more information on wastewater testing in Ottawa, please see the [contact](https://613covid.ca/contact/) page.
 
 Citations:
 
-1.	Health Protection and Promotion Act, R.S.O. 1990, c. H.7. https://www.ontario.ca/laws/statute/90h07?search=diseases+of+public+health+significance. 
+1.  Health Protection and Promotion Act, R.S.O. 1990, c. H.7. <https://www.ontario.ca/laws/statute/90h07?search=diseases+of+public+health+significance>.
 
-2.	Mercier, É. et al. Wastewater surveillance of influenza activity: Early detection, surveillance, and subtyping in city and neighbourhood communities (preprint). (2022) doi:10.1101/2022.06.28.22276884. 
+2.  Mercier, É. et al. Wastewater surveillance of influenza activity: Early detection, surveillance, and subtyping in city and neighbourhood communities (preprint). (2022) <doi:10.1101/2022.06.28.22276884>.
 
 ------------------------------------------------------------------------
 
@@ -428,8 +431,6 @@ You can learn more about wastewater epidemiology and its role in COVID-19 survei
 ## Definitions
 
 \* A 7-day average is generated by averaging the levels from a given day with the six previous days. The average is termed "rolling" as it changes each day.
-
-\* For new cases, the reported date is the day the test result is reported by the laboratory. Episode date is the approximate date of COVID-19 infection estimated from information available: the date of symptom onset, test date, or the reported date.
 
 \* Percent positivity refers to the percentage of individuals tested for either COVID-19 infection or influenza A infection in a given day that test positive.
 


### PR DESCRIPTION
Removed the figure and text that referenced 'cases' or used case data from the index page rmd. Also removed text referencing cases or case dates.

Commented above the figure that uses case data for the wastewater page rmd. Also removed text referencing cases or case dates and figures/comparators.

@rvyuha - merged with a previous branch to ensure that the flu and RSV figures were included in the rmd files, but this may mean they also need to be updated with any of the debugging work you've since done (sorry)