### PR TITLE
Update GitHub Actions workflows to install `libtbb-dev` alongside `li…

### DIFF
--- a/.github/workflows/dataset_creation.yml
+++ b/.github/workflows/dataset_creation.yml
@@ -23,7 +23,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: "4.1.1"
-      - run: sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libtbb-dev
       - name: Install libnode-dev
         run: sudo apt-get install libnode-dev
       - name: Install snap version of nodejs

--- a/.github/workflows/page_update.yml
+++ b/.github/workflows/page_update.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           cache-version: 1
       - uses: r-lib/actions/setup-pandoc@v2
-      - name: Install libcurl4-openssl-dev
+      - name: Install libcurl4-openssl-dev and libtbb-dev
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing libcurl4-openssl-dev || (sleep 30 && sudo apt-get update && sudo apt-get install -y --fix-missing libcurl4-openssl-dev)
+          sudo apt-get install -y --fix-missing libcurl4-openssl-dev libtbb-dev || (sleep 30 && sudo apt-get update && sudo apt-get install -y --fix-missing libcurl4-openssl-dev libtbb-dev)
       - name: Install harfbuzz and fribidi
         run: |
           sudo apt-get install -y --fix-missing libharfbuzz-dev libfribidi-dev || (sleep 30 && sudo apt-get update && sudo apt-get install -y --fix-missing libharfbuzz-dev libfribidi-dev)


### PR DESCRIPTION
…bcurl4-openssl-dev` to fix error in GitHub Action log where EpiNow2 failed to install due to a missing intel TBB dependency.