### PR TITLE
More errors encounted running page_update.yml github action: Error: E…

### DIFF
--- a/.github/workflows/dataset_creation.yml
+++ b/.github/workflows/dataset_creation.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup-r
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.1.1"
+          r-version: "4.5.3"
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcurl4-openssl-dev libtbb-dev
       - name: Install libnode-dev
         run: sudo apt-get install libnode-dev

--- a/.github/workflows/page_update.yml
+++ b/.github/workflows/page_update.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           r-version: '4.5.3'
           use-public-rspm: true
-      - uses: r-lib/actions/setup-renv@v2
-        with:
-          cache-version: 1
-      - uses: r-lib/actions/setup-pandoc@v2
       - name: Install libcurl4-openssl-dev and libtbb-dev
         run: |
           sudo apt-get update
@@ -46,6 +42,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --fix-missing libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libuv1-dev || (sleep 30 && sudo apt-get update && sudo apt-get install -y --fix-missing libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libuv1-dev)
+      - uses: r-lib/actions/setup-renv@v2
+        with:
+          cache-version: 1
+      - uses: r-lib/actions/setup-pandoc@v2
       - name: install hugo
         run: Rscript -e 'blogdown::install_hugo(version = "0.123.0")'
       - name: Render website

--- a/renv.lock
+++ b/renv.lock
@@ -102,10 +102,10 @@
     },
     "StanHeaders": {
       "Package": "StanHeaders",
-      "Version": "2.21.0-7",
+      "Version": "2.32.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0459d4dd7a8c239be18469a30c23dd4b"
+      "Hash": "0e4a778ef603d1591ba5f21226162319"
     },
     "askpass": {
       "Package": "askpass",
@@ -829,10 +829,10 @@
     },
     "rstan": {
       "Package": "rstan",
-      "Version": "2.21.3",
+      "Version": "2.32.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8fa400c2cf6409067a4515581ae4d99b"
+      "Hash": "0e4a778ef603d1591ba5f21226162319"
     },
     "rstudioapi": {
       "Package": "rstudioapi",
@@ -1016,10 +1016,10 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.29",
+      "Version": "0.41",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e2e5fb1a74fbb68b27d6efc5372635dc"
+      "Hash": "0e4a778ef603d1591ba5f21226162319"
     },
     "xml2": {
       "Package": "xml2",


### PR DESCRIPTION
…rror: failed to install "EpiNow2", "blogdown".

Moved system dependency installation (apt-get) before setup-renv in .github/workflows/page_update.yml. This ensures libtbb-dev is present when renv::restore() is automatically triggered. Updated xfun (0.29 → 0.41) in renv.lock to resolve a namespace error (object ‘attr’ is not exported by 'namespace:xfun') caused by version incompatibility.